### PR TITLE
Add tzdata installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o tasmota-exporter ./cmd/tasmota-exporter
 
 # Final stage
 FROM alpine:latest
+RUN apk add --no-cache tzdata
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- install `tzdata` in the final Docker image to allow timezone configuration

## Testing
- `go build ./cmd/tasmota-exporter` *(fails: Forbidden downloading modules)*

------
https://chatgpt.com/codex/tasks/task_e_685596a49fe08326a9ff3af958ce0a4e